### PR TITLE
fix: use small buffers to make tests more efficient

### DIFF
--- a/conn/batchsize_default.go
+++ b/conn/batchsize_default.go
@@ -1,0 +1,12 @@
+//go:build !testsmallbuffers
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package conn
+
+const (
+	IdealBatchSize = 128 // maximum number of packets handled per read and write
+)

--- a/conn/batchsize_testsmall.go
+++ b/conn/batchsize_testsmall.go
@@ -1,0 +1,16 @@
+//go:build testsmallbuffers
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ *
+ * Modified by Coder for test environments to reduce memory usage.
+ */
+
+package conn
+
+// IdealBatchSize is reduced for tests to minimize memory usage.
+// In production, this is 128 (see batchsize_default.go), but tests don't need
+// the full batch capacity and this significantly reduces memory overhead
+// from wireguard buffer pools (~8MB per connection down to ~256KB).
+const IdealBatchSize = 4

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -15,10 +15,6 @@ import (
 	"strings"
 )
 
-const (
-	IdealBatchSize = 128 // maximum number of packets handled per read and write
-)
-
 // A ReceiveFunc receives at least one packet from the network and writes them
 // into packets. On a successful read it returns the number of elements of
 // sizes, packets, and endpoints that should be evaluated. Some elements of

--- a/device/queueconstants_android.go
+++ b/device/queueconstants_android.go
@@ -1,3 +1,5 @@
+//go:build android && !testsmallbuffers
+
 /* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.

--- a/device/queueconstants_default.go
+++ b/device/queueconstants_default.go
@@ -1,4 +1,4 @@
-//go:build !android && !ios && !windows
+//go:build !android && !ios && !windows && !testsmallbuffers
 
 /* SPDX-License-Identifier: MIT
  *

--- a/device/queueconstants_ios.go
+++ b/device/queueconstants_ios.go
@@ -1,4 +1,4 @@
-//go:build ios
+//go:build ios && !testsmallbuffers
 
 /* SPDX-License-Identifier: MIT
  *

--- a/device/queueconstants_testsmall.go
+++ b/device/queueconstants_testsmall.go
@@ -1,0 +1,21 @@
+//go:build testsmallbuffers
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ *
+ * Modified by Coder for test environments to reduce memory usage.
+ */
+
+package device
+
+import "github.com/tailscale/wireguard-go/conn"
+
+const (
+	QueueStagedSize            = conn.IdealBatchSize
+	QueueOutboundSize          = 64   // Reduced from 1024 for tests
+	QueueInboundSize           = 64   // Reduced from 1024 for tests
+	QueueHandshakeSize         = 64   // Reduced from 1024 for tests
+	MaxSegmentSize             = 2048 // Reduced from 65535 for tests (enough for typical packets)
+	PreallocatedBuffersPerPool = 0    // Disable and allow for infinite memory growth
+)

--- a/device/queueconstants_windows.go
+++ b/device/queueconstants_windows.go
@@ -1,3 +1,5 @@
+//go:build !testsmallbuffers
+
 /* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.


### PR DESCRIPTION
_Warning: vibe-coded!_

Dependency of https://github.com/coder/coder/pull/21251

I asked Opus 4.5 to justify its changes:

  1. IdealBatchSize: 128 → 4

  What it controls: Number of packets handled per read/write batch operation.

  Memory impact: This affects container pool allocations - each container holds BatchSize() element pointers. With 128, you get slices of 128 pointers; with 4, just 4 pointers.

  Safety: ✅ Safe. If more than 4 packets need to be processed, wireguard simply does multiple batch operations. This only affects throughput, not correctness. Tests don't need high throughput.

  ---
  2. QueueOutboundSize/InboundSize/HandshakeSize: 1024 → 64

  What they control: Channel buffer sizes for packet queues.

  Safety: ✅ Safe. If queues fill up, backpressure applies (blocks until space available). Tests don't generate sustained high packet rates. 64 is still a generous buffer for test scenarios.

  ---
  3. MaxSegmentSize: 65535 → 2048

  What it controls: Maximum UDP datagram size. This is the size of [MaxMessageSize]byte arrays allocated for packet buffers.

  Memory impact: This is the dominant factor. Each message buffer is MaxSegmentSize bytes. With 65535 bytes each, these quickly consume gigabytes across many connections.

  Safety: ✅ Safe - and here's why:

  | Platform         | MaxSegmentSize |
  |------------------|----------------|
  | Default (Linux)  | 65535          |
  | Windows          | 2016 (2048-32) |
  | iOS              | 1700           |
  | Android          | 2200           |
  | testsmallbuffers | 2048           |

  Critical insight: Windows and iOS run in production with values ≤2048. Our test value of 2048 is:
  - Equal to Windows production value
  - Larger than iOS production value (1700)
  - Larger than standard MTU (1500) + WireGuard overhead (~80 bytes)

  Since iOS devices successfully run WireGuard in production with MaxSegmentSize=1700, our test value of 2048 is definitively safe.

  ---
  4. PreallocatedBuffersPerPool: 0 (unchanged)

  Already 0 in default config, meaning sync.Pool handles allocation dynamically. No change needed.

  ---
  Memory Calculation

  Per-device with default settings:
  - Message buffers: ~65KB each, pooled
  - Container slices: 128 pointers × multiple pools

  Per-device with testsmallbuffers:
  - Message buffers: ~2KB each, pooled
  - Container slices: 4 pointers × multiple pools

  Result: ~32x reduction in per-buffer memory, compounding across hundreds of test connections.

  ---
  Verdict

  All changes are justified and safe:
  1. IdealBatchSize=4: Affects only throughput, not correctness
  2. Queue sizes=64: Provides backpressure, doesn't fail
  3. MaxSegmentSize=2048: Production-proven on Windows and iOS - this is the key insight that validates the choice