### PR TITLE
fix: use smaller batch sizes under build tag for more efficient tests

### DIFF
--- a/conn/batchsize_default.go
+++ b/conn/batchsize_default.go
@@ -1,0 +1,12 @@
+//go:build !testsmallbatch
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ */
+
+package conn
+
+const (
+	IdealBatchSize = 128 // maximum number of packets handled per read and write
+)

--- a/conn/batchsize_testsmall.go
+++ b/conn/batchsize_testsmall.go
@@ -1,0 +1,16 @@
+//go:build testsmallbatch
+
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2017-2023 WireGuard LLC. All Rights Reserved.
+ *
+ * Modified by Coder for test environments to reduce memory usage.
+ */
+
+package conn
+
+// IdealBatchSize is reduced for tests to minimize memory usage.
+// In production, this is 128 (see batchsize_default.go), but tests don't need
+// the full batch capacity and this significantly reduces memory overhead
+// from wireguard buffer pools (~8MB per connection down to ~256KB).
+const IdealBatchSize = 4

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -15,10 +15,6 @@ import (
 	"strings"
 )
 
-const (
-	IdealBatchSize = 128 // maximum number of packets handled per read and write
-)
-
 // A ReceiveFunc receives at least one packet from the network and writes them
 // into packets. On a successful read it returns the number of elements of
 // sizes, packets, and endpoints that should be evaluated. Some elements of


### PR DESCRIPTION
`IdealBatchSize` is used to read batches of packets from the OS in a single syscall. By reducing the number of preallocated buffers in the batch, we reduce the memory consumption from ~8MiB per connection (`128 batch size * 65KiB segment size`) to 256KiB (`4 batch size * 65KiB segment size`). Segment size is defined [here](https://github.com/coder/wireguard-go/blob/master/device/queueconstants_default.go#L17).

This results in a significant memory reduction (~70% reduction in heap) in `coder/coder` test runs: see https://github.com/coder/coder/pull/21251.

Under normal conditions this change is not required because `coder/coder` only creates a single Wireguard device, but the `coder/coder` tests are largely integration-style and spin up many servers over their runtime.